### PR TITLE
Enable Git info

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -3,6 +3,8 @@ languageCode = "en-us"
 title = "Technology Toolbox"
 theme = "techtoolbox-hugo"
 
+enableGitInfo = true
+
 [markup]
   [markup.highlight]
     noClasses = false # Use class attributes for code syntax highlighting


### PR DESCRIPTION
This will update the "Lastmod" parameter for each page using the last git commit date for that content file.

References:

- https://gohugo.io/variables/git/
- https://gohugo.io/getting-started/configuration/#enablegitinfo
b1acf1